### PR TITLE
Fable 5 review fixes: dispatch listener + delivery dedup

### DIFF
--- a/.github/workflows/build-blog-data.yml
+++ b/.github/workflows/build-blog-data.yml
@@ -2,6 +2,8 @@ name: Build blog data
 
 on:
   workflow_dispatch:
+  repository_dispatch:
+    types: [predictions-complete]
   workflow_run:
     workflows: ["Cricinfo Scrape"]
     types: [completed]
@@ -13,6 +15,9 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    # Only skip when triggered by a failed/cancelled upstream workflow_run -
+    # workflow_dispatch and repository_dispatch (predictions-complete) always run.
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/cricsheet-daily.yml
+++ b/.github/workflows/cricsheet-daily.yml
@@ -377,9 +377,10 @@ jobs:
                 # bind_rows handles mismatched columns gracefully (fills with NA)
                 combined <- dplyr::bind_rows(harmonize_types(list(existing_df, new_df)))
 
-                # Deduplicate if key column provided
-                if (!is.null(key_col) && key_col %in% names(combined)) {
-                  combined <- combined[!duplicated(combined[[key_col]]), ]
+                # Deduplicate if key column(s) provided (key_col may be a
+                # composite key, e.g. c("match_id", "innings"))
+                if (!is.null(key_col) && all(key_col %in% names(combined))) {
+                  combined <- combined[!duplicated(combined[key_col]), ]
                 }
               } else {
                 combined <- new_df
@@ -392,14 +393,15 @@ jobs:
 
             merge_and_write(new_matches, "matches.parquet", "match_id")
             merge_and_write(new_players, "players.parquet", "player_id")
-            merge_and_write(new_innings, "match_innings.parquet")
-            merge_and_write(new_powerplays, "innings_powerplays.parquet")
+            merge_and_write(new_innings, "match_innings.parquet", c("match_id", "innings"))
+            merge_and_write(new_powerplays, "innings_powerplays.parquet", "powerplay_id")
 
             # Merge delivery partitions
             for (pk in affected_partitions) {
               merge_and_write(
                 new_deliveries_by_partition[[pk]],
-                paste0("deliveries_", pk, ".parquet")
+                paste0("deliveries_", pk, ".parquet"),
+                "delivery_id"
               )
             }
           }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,7 +95,7 @@ Workflows live in THIS repo (`.github/workflows/`) so `GITHUB_TOKEN` has release
 
 **Build Blog Data:**
 - Downloads skill parquets from `player_rating`, `team_rating`, `venue_rating` releases
-- Aggregates into compact leaderboard/ranking parquets (9 files: batting/bowling/teams/venues × format)
+- Aggregates into compact leaderboard/ranking parquets (16 files: 12 leaderboard [batting/bowling/teams/venues × format] + 3 ball-by-ball [balls-{t20i,odi,test}] + player-names.parquet)
 - Uploads to Cloudflare R2 bucket `inthegame-data` via `wrangler`
 - Trigger: `gh workflow run build-blog-data.yml --repo peteowen1/bouncerdata --ref dev`
 
@@ -163,7 +163,7 @@ Uses DuckDB schemas: `cricsheet.*`, `cricinfo.*`, `main.*` (see `bouncer/CLAUDE.
 - **cricinfo.fixtures**: Schedule/results index
 - **main.team_elo**: Team ELO ratings per match
 - **main.{format}_player_skill**: Player skill indices (test, odi, t20)
-- **main.{format}_3way_player_elo**: 3-way ELO ratings (batter, bowler, venue)
+- **main.{format}_3way_elo**: 3-way ELO ratings (batter, bowler, venue)
 - **main.{format}_team_skill**: Team batting/bowling skill indices
 - **main.{format}_venue_skill**: Venue run/wicket/boundary rates
 - **main.{format}_score_projection**: Projected scores per delivery
@@ -175,7 +175,7 @@ See `bouncer/CLAUDE.md` for full schema details including column names and deliv
 | Secret | Used By | Purpose |
 |--------|---------|---------|
 | `GITHUB_TOKEN` | All workflows | Release uploads (auto-provided) |
-| `BOUNCERDATA_PAT` | cricsheet-daily | Cross-repo release uploads |
+| `WORKFLOW_PAT` | cricsheet-daily, cricinfo-daily | Cross-repo release uploads + repository_dispatch |
 | `CLOUDFLARE_R2_TOKEN` | build-blog-data | Cloudflare R2 API token |
 | `CLOUDFLARE_ACCOUNT_ID` | build-blog-data | Cloudflare account ID |
 


### PR DESCRIPTION
## Summary
- build-blog-data.yml had no listener for the predictions-complete dispatch and could run on a failed scrape; now triggers correctly and guards on success
- cricsheet-daily.yml merge now dedups match_innings/innings_powerplays/delivery partitions on a composite key instead of silently duplicating rows on re-runs

## Context
Part of a cross-verse Fable 5 deep-review pass (bouncerverse/FABLE-REVIEW.md).

## Test plan
- [x] CI green (Build blog data)
- [x] Edited workflow YAML validated; dedup logic reasoned through against known re-run scenarios