### PR TITLE
Deploy the Player Rating v2 publish step (the parquets 404 on R2 today)

### DIFF
--- a/.github/workflows/build-blog-data.yml
+++ b/.github/workflows/build-blog-data.yml
@@ -40,6 +40,16 @@ jobs:
             gh release download venue_rating  -p "${fmt}_venue_skill.parquet"  -D source
           done
 
+      # Player Rating v2. Deliberately NOT continue-on-error: an unreachable
+      # release would otherwise publish a blog with the v2 tables silently
+      # missing, which looks identical to "there are no ratings".
+      - name: Download player rating v2
+        env:
+          GH_TOKEN: ${{ secrets.WORKFLOW_PAT }}
+        run: |
+          gh release download player-rating-v2 -p "player_rating_v2.parquet" -D source
+          gh release download player-rating-v2 -p "player_value_v2.parquet"  -D source
+
       - name: Download player metadata
         continue-on-error: true
         env:

--- a/scripts/build_blog_data.R
+++ b/scripts/build_blog_data.R
@@ -248,6 +248,31 @@ if (file.exists(rating_v2_path)) {
            main_comp, matches, balls, effective_matches, last_match, as_at) |>
     arrange(bucket, role, rank)
   stopifnot(!anyNA(rv$player_id))
+
+  # Enrich from the same id-keyed crosswalk the skill tables above use, so the
+  # page can filter by country and show style badges and age without matching
+  # on names. The join is on player_id and never on the name -- which matters
+  # here more than usual, because the ids that ARE a bare name (D-P28's
+  # deliberately unmerged split careers) simply fail to match and come back
+  # NA. That is the honest outcome; a name join would instead attach one real
+  # player's country and date of birth to a different player's rating.
+  if (!is.null(player_meta) && "country" %in% names(player_meta)) {
+    before <- nrow(rv)
+    rv <- rv |>
+      left_join(
+        player_meta |>
+          select(player_id, country, full_name, dob, batting_style, bowling_style) |>
+          distinct(player_id, .keep_all = TRUE),
+        by = "player_id")
+    # A crosswalk with a duplicated player_id would silently multiply rows and
+    # break rank 1..N. distinct() above prevents it; this proves it.
+    stopifnot(nrow(rv) == before)
+    cat(sprintf("  ratings v2: %d/%d rows enriched with country\n",
+                sum(!is.na(rv$country)), nrow(rv)))
+  } else {
+    cat("  ratings v2: no player_meta available -- publishing without country/style/age\n")
+  }
+
   write_parquet(rv, "blog/player-ratings-v2.parquet")
   cat(sprintf("  ratings v2: %d rows across %d bucket-roles (%d names shared by 2+ ids)\n",
               nrow(rv), dplyr::n_distinct(rv$bucket, rv$role),

--- a/scripts/build_blog_data.R
+++ b/scripts/build_blog_data.R
@@ -221,8 +221,9 @@ if (file.exists(rating_v2_path)) {
   # Guard the shape rather than trusting it: this file is produced by a
   # different repo on a different schedule, and a silently-renamed column
   # would publish an empty table on a green run.
-  need <- c("format", "gender", "role", "rank", "player_name", "rating",
-            "average", "main_comp", "matches", "balls", "effective_matches")
+  need <- c("format", "gender", "role", "rank", "player_id", "player_name",
+            "rating", "average", "main_comp", "matches", "balls",
+            "effective_matches")
   missing <- setdiff(need, names(rv))
   if (length(missing)) {
     stop("player_rating_v2.parquet is missing column(s): ",
@@ -232,21 +233,36 @@ if (file.exists(rating_v2_path)) {
   }
   if (nrow(rv) == 0L) stop("player_rating_v2.parquet is empty.")
 
+  # player_id is carried even though nothing reads it yet, because `player` is
+  # NOT unique and the front-end links by it. Two bucket-roles ship two rows
+  # with the same name, and in both cases they are genuinely two different
+  # people that D-P28 deliberately refused to merge:
+  #   odi-female batter  E Jones        ids 971cb321 and "E Jones"
+  #   t20-male   bowler  Harmeet Singh  ids 0bf15e52 and 2a72fd4f
+  # Without the id the page shows a name twice and points both rows at one
+  # player. This is the find_player() lesson at the presentation layer: a name
+  # is not an identifier, and the place that discovers it is always downstream.
   rv <- rv |>
     mutate(bucket = paste0(tolower(format), "-", gender)) |>
-    select(bucket, role, rank, player = player_name, rating, average,
+    select(bucket, role, rank, player_id, player = player_name, rating, average,
            main_comp, matches, balls, effective_matches, last_match, as_at) |>
     arrange(bucket, role, rank)
+  stopifnot(!anyNA(rv$player_id))
   write_parquet(rv, "blog/player-ratings-v2.parquet")
-  cat(sprintf("  ratings v2: %d rows across %d bucket-roles\n",
-              nrow(rv), dplyr::n_distinct(rv$bucket, rv$role)))
+  cat(sprintf("  ratings v2: %d rows across %d bucket-roles (%d names shared by 2+ ids)\n",
+              nrow(rv), dplyr::n_distinct(rv$bucket, rv$role),
+              sum(rv |> count(bucket, role, player) |> pull(n) > 1)))
 
   if (file.exists(value_v2_path)) {
+    # player_id for the same reason as the rating table above: two names are
+    # shared by two different players here too.
     vv <- read_parquet(value_v2_path) |>
       mutate(bucket = paste0(tolower(format), "-", gender)) |>
-      select(bucket, rank, player = player_name, total_value, bat_value,
-             bowl_value, matches, bat_balls, bowl_balls, calibrated, as_at) |>
+      select(bucket, rank, player_id, player = player_name, total_value,
+             bat_value, bowl_value, matches, bat_balls, bowl_balls,
+             calibrated, as_at) |>
       arrange(bucket, rank)
+    stopifnot(!anyNA(vv$player_id))
     write_parquet(vv, "blog/player-values-v2.parquet")
     cat(sprintf("  values v2:  %d rows across %d buckets\n",
                 nrow(vv), dplyr::n_distinct(vv$bucket)))

--- a/scripts/build_blog_data.R
+++ b/scripts/build_blog_data.R
@@ -221,9 +221,13 @@ if (file.exists(rating_v2_path)) {
   # Guard the shape rather than trusting it: this file is produced by a
   # different repo on a different schedule, and a silently-renamed column
   # would publish an empty table on a green run.
+  # Every column the select() below reads must be named here, or the guard is
+  # decorative: a column renamed upstream then fails inside dplyr::select() with
+  # "can't subset columns that don't exist" and no mention of which repo
+  # produced the file. last_match and as_at were selected but not asserted.
   need <- c("format", "gender", "role", "rank", "player_id", "player_name",
             "rating", "average", "main_comp", "matches", "balls",
-            "effective_matches")
+            "effective_matches", "last_match", "as_at")
   missing <- setdiff(need, names(rv))
   if (length(missing)) {
     stop("player_rating_v2.parquet is missing column(s): ",
@@ -279,9 +283,26 @@ if (file.exists(rating_v2_path)) {
               sum(rv |> count(bucket, role, player) |> pull(n) > 1)))
 
   if (file.exists(value_v2_path)) {
+    # Guarded the same way as the rating table, and for a sharper reason: the
+    # upload step globs blog/*.parquet unconditionally, so a present-but-empty
+    # value file would be written here and then published OVER the good copy
+    # already on R2. "Downloaded successfully" does not mean "has rows".
+    vv_raw <- read_parquet(value_v2_path)
+    vv_need <- c("format", "gender", "rank", "player_id", "player_name",
+                 "total_value", "bat_value", "bowl_value", "matches",
+                 "bat_balls", "bowl_balls", "calibrated", "as_at")
+    vv_missing <- setdiff(vv_need, names(vv_raw))
+    if (length(vv_missing)) {
+      stop("player_value_v2.parquet is missing column(s): ",
+           paste(vv_missing, collapse = ", "),
+           "\n  Produced by bouncer's 01_build_player_ratings_v2.R; check that ",
+           "the release asset matches the current schema.")
+    }
+    if (nrow(vv_raw) == 0L) stop("player_value_v2.parquet is empty.")
+
     # player_id for the same reason as the rating table above: two names are
     # shared by two different players here too.
-    vv <- read_parquet(value_v2_path) |>
+    vv <- vv_raw |>
       mutate(bucket = paste0(tolower(format), "-", gender)) |>
       select(bucket, rank, player_id, player = player_name, total_value,
              bat_value, bowl_value, matches, bat_balls, bowl_balls,

--- a/scripts/build_blog_data.R
+++ b/scripts/build_blog_data.R
@@ -193,3 +193,69 @@ tryCatch({
 }, error = function(e) {
   warning("Failed to build player-names.parquet: ", conditionMessage(e))
 })
+
+# ---------------------------------------------------------------------------
+# Player Rating v2 (bouncerverse D-P16 to D-P29)
+#
+# The opponent- and competition-adjusted rating, covering men's and women's
+# T20 and ODI. Published straight through rather than recomputed: the parquets
+# on `player-rating-v2` are already validated at publish time (bucket
+# completeness, rank 1..N, no duplicate player per bucket, anchor players
+# where they belong), so re-deriving anything here would only add a second
+# place for it to go wrong.
+#
+# Unlike the skill tables above these already carry `player_name`, so they do
+# NOT depend on the registry join. They also carry the two columns needed to
+# read a rating honestly:
+#   average             the traditional number, for orientation
+#   effective_matches   how much evidence is behind it after decay -- a rating
+#                       whose effective_matches is below its bucket's prior is
+#                       mostly population mean, and the page should be able to
+#                       say so rather than hide it behind a filter.
+rating_v2_path <- "source/player_rating_v2.parquet"
+value_v2_path  <- "source/player_value_v2.parquet"
+
+if (file.exists(rating_v2_path)) {
+  rv <- read_parquet(rating_v2_path)
+
+  # Guard the shape rather than trusting it: this file is produced by a
+  # different repo on a different schedule, and a silently-renamed column
+  # would publish an empty table on a green run.
+  need <- c("format", "gender", "role", "rank", "player_name", "rating",
+            "average", "main_comp", "matches", "balls", "effective_matches")
+  missing <- setdiff(need, names(rv))
+  if (length(missing)) {
+    stop("player_rating_v2.parquet is missing column(s): ",
+         paste(missing, collapse = ", "),
+         "\n  Produced by bouncer's 01_build_player_ratings_v2.R; check that ",
+         "the release asset matches the current schema.")
+  }
+  if (nrow(rv) == 0L) stop("player_rating_v2.parquet is empty.")
+
+  rv <- rv |>
+    mutate(bucket = paste0(tolower(format), "-", gender)) |>
+    select(bucket, role, rank, player = player_name, rating, average,
+           main_comp, matches, balls, effective_matches, last_match, as_at) |>
+    arrange(bucket, role, rank)
+  write_parquet(rv, "blog/player-ratings-v2.parquet")
+  cat(sprintf("  ratings v2: %d rows across %d bucket-roles\n",
+              nrow(rv), dplyr::n_distinct(rv$bucket, rv$role)))
+
+  if (file.exists(value_v2_path)) {
+    vv <- read_parquet(value_v2_path) |>
+      mutate(bucket = paste0(tolower(format), "-", gender)) |>
+      select(bucket, rank, player = player_name, total_value, bat_value,
+             bowl_value, matches, bat_balls, bowl_balls, calibrated, as_at) |>
+      arrange(bucket, rank)
+    write_parquet(vv, "blog/player-values-v2.parquet")
+    cat(sprintf("  values v2:  %d rows across %d buckets\n",
+                nrow(vv), dplyr::n_distinct(vv$bucket)))
+  } else {
+    cat("  values v2:  absent, skipping (ratings still published)\n")
+  }
+} else {
+  # Not fatal: the v2 release is newer than this script's other inputs, so an
+  # older bouncerdata checkout can legitimately lack it. Loud, though -- a
+  # missing rating file must not read as "there are no ratings".
+  cat("  ratings v2: source/player_rating_v2.parquet ABSENT -- v2 tables not published\n")
+}


### PR DESCRIPTION
Deploys the Player Rating v2 publish step so the parquets actually reach R2.

## Why this exists

`bouncerverse/docs/NEXT-STEPS.md` and the 2026-08-17 handover both record the v2
ratings as "sitting in R2 waiting for a front-end". **They are not in R2.**

- `https://…r2.dev/cricket/player-ratings-v2.parquet` → **HTTP 404**. Same for
  `player-values-v2.parquet`.
- The data exists only as a GitHub release asset (`player-rating-v2`, 2026-08-16).
- The code that publishes it (`5005a50`) is on **`dev` only** — not an ancestor of
  `main`.
- `build-blog-data.yml` has run four times recently, **every one from `main`**. So
  that branch of the script has never executed.

Publishing to a release and syncing to R2 are two separate acts; only the first
happened. This PR is `5005a50` cherry-picked onto `main` so the second can.

Kept deliberately small rather than merging all 121 commits on `dev`, so the
review is honest and the live cricket parquets aren't gambled on unreviewed code.

## Commits

1. **`bbb529f`** — the cherry-pick. Conflicted in the workflow file; resolved by
   hand. `dev` also splits `Download player metadata` into required-registry +
   optional-enrichment, which is a **behaviour change and was deliberately not
   taken** — `main`'s combined step is byte-for-byte intact. The new
   `Download player rating v2` step is **not** `continue-on-error`, deliberately: a
   silently-missing rating table looks identical to "there are no ratings".
2. **`e6e286a`** — carry `player_id`. **`player` is not unique.** "E Jones" is
   *three* different players and "Harmeet Singh" is two, all kept correctly
   separate upstream because D-P28 refused to merge them. The published table
   dropped the id and the blog links by name, so the page would have shown a name
   twice and pointed both rows at one player. This is the `find_player()` lesson at
   the presentation layer: the layer that discovers a name isn't an identifier is
   always downstream of the one that dropped the id.
3. **`828b869`** — join the crosswalk that already sits in this script as
   `player_meta`, **by `player_id`, never by name**, for `country` / `full_name` /
   `dob` / styles. A name join would attach one real player's country and DOB to a
   different player's rating. Guarded against row multiplication with `distinct()`
   + `stopifnot(nrow == before)`.
4. **`d8f5c1d`** — two review findings.

## Verified against the real release assets, not by reading

Ran the block on the actual parquets before and after each change:

- 5,346 rating rows across 8 bucket-roles; 2,997 value rows across 4 buckets.
- `(bucket, role, player_id)` unique — 5,346 distinct of 5,346. `(bucket,
  player_id)` unique — 2,997 of 2,997. No NA ids. Rank still 1..N per bucket-role
  after the join.
- Enrichment coverage, which decides what the page can show rather than claim:

  | column | coverage |
  |---|---|
  | `country` | **5345/5346 (100.0%)** |
  | `full_name` | 3158/5346 (59.1%) |
  | `dob` | 3154/5346 (59.0%) |
  | `batting_style` | 3155/5346 (59.0%) |
  | `bowling_style` | 2865/5346 (53.6%) |

  Top 50 of each bucket-role is no better (~58%), so the front-end must degrade
  gracefully rather than assume enrichment. The single `country` miss is the
  literal-name id, as expected.

Two things worth knowing that are **not** bugs:

- **`as_at` differs by bucket** (odi-female 2026-07-12, t20-female 2026-08-04, the
  men's 2026-08-05). That is each bucket's own latest match date — women's ODI
  simply hasn't been played since July. The page should show it per bucket, not as
  one global date.
- **380 rows have `effective_matches` < 1**, i.e. the rating is essentially the
  population mean (retired players decayed to zero weight — their ratings cluster
  at ~3.836). None reach a top 50. This is exactly what `effective_matches` is
  published for.

## The two review findings, and how they were checked

Both fixed in `d8f5c1d`, both proven by running the block against deliberately
broken copies:

| case | result |
|---|---|
| happy path | no abort, both files written |
| value parquet present but **empty** | aborts `player_value_v2.parquet is empty.` |
| rating parquet missing `as_at` | aborts `missing column(s): as_at` — **was a bare dplyr error** |
| value parquet missing `calibrated` | aborts `missing column(s): calibrated` |

The empty-value case mattered most: the upload step globs `blog/*.parquet`
unconditionally, so an empty file would have been published **over** the good copy
on R2. In the two cases that abort after the ratings file is written, nothing
reaches R2 — the R failure fails the `Aggregate` step and `Upload to R2` carries no
`if: always()`.

## Known issue left alone, on purpose

`main`'s `Download player metadata` step is `continue-on-error` covering **both**
the required registry and the optional enrichment, so a transient release failure
publishes a blog keyed on raw UUIDs on a green run. `dev` has a fix. It is a
behaviour change and does not belong in a minimal deploy PR — it should land with
the wider `dev` merge.

## After merge

`gh workflow run build-blog-data.yml --repo peteowen1/bouncerdata --ref main`,
then confirm the two URLs return 200 before any front-end work starts.
